### PR TITLE
Updated outdated cloudformation-zookeeper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CloudFormation templates for a [Mesos](http://mesos.apache.org) cluster running the [Marathon](https://github.com/mesosphere/marathon) framework.
 
 Prerequisites:
-* An Exhibitor-managed ZooKeeper cluster such as provided by [thefactory/cloudformation-zookeeper](https://github.com/thefactory/cloudformation-zookeeper). Specifically, you'll need:
+* An Exhibitor-managed ZooKeeper cluster such as provided by [mbabineau/cloudformation-zookeeper](https://github.com/mbabineau/cloudformation-zookeeper). Specifically, you'll need:
     - An Exhibitor endpoint for ZK node discovery
     - A ZK client security group to associate with the Mesos nodes
 
@@ -40,7 +40,7 @@ Inbound rules are at your discretion, but you may want to include access to:
 * `8080 [tcp]` - Marathon port
 
 ### 3. Set up ZooKeeper
-You can use the instructions and template at [thefactory/cloudformation-zookeeper](https://github.com/thefactory/cloudformation-zookeeper), or you can use an existing cluster.
+You can use the instructions and template at [mbabineau/cloudformation-zookeeper](https://github.com/mbabineau/cloudformation-zookeeper), or you can use an existing cluster.
 
 We'll need two things:
 * `ExhibitorDiscoveryUrl` - a URL that returns a list of active ZK nodes. The expected format is that of Exhibitor's `/cluster/list` call. Example response:


### PR DESCRIPTION
As per the instructions on https://github.com/thefactory/cloudformation-zookeeper the new repo is hosted at https://github.com/mbabineau/cloudformation-zookeeper.
